### PR TITLE
Ensure migrations are SQLite compatible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM debian:bullseye-20230612-slim AS runtime
 
 RUN useradd -c 'atuin user' atuin && mkdir /config && chown atuin:atuin /config
 # Install ca-certificates for webhooks to work
-RUN apt update && apt install ca-certificates -y && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install ca-certificates sqlite3 -y && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 USER atuin

--- a/migrations/20230608124200_create_history.sql
+++ b/migrations/20230608124200_create_history.sql
@@ -1,15 +1,12 @@
 create table history (
-	id bigserial primary key,
-	client_id text not null unique, -- the client-generated ID
-	user_id bigserial not null,     -- allow multiple users
-	hostname text not null,         -- a unique identifier from the client (can be hashed, random, whatever)
-	timestamp timestamp not null,   -- one of the few non-encrypted metadatas
-
-	data text not null,    -- store the actual history data, encrypted. I don't wanna know!
-
-	created_at timestamp not null default current_timestamp,
-	deleted_at timestamp
+    id integer primary key autoincrement,
+    client_id text not null unique,
+    user_id integer not null,
+    hostname text not null,
+    timestamp text not null,
+    data text not null,
+    created_at text not null default current_timestamp,
+    deleted_at text
 );
 
--- queries will all be selecting the ids of history for a user, that has been deleted
 create unique index history_deleted_index on history(client_id, user_id, deleted_at);

--- a/migrations/20230608124201_create_users.sql
+++ b/migrations/20230608124201_create_users.sql
@@ -1,11 +1,10 @@
 create table users (
-	id bigserial primary key,               -- also store our own ID
-	username varchar(32) not null unique,   -- being able to contact users is useful
-	email varchar(128) not null unique,     -- being able to contact users is useful
-	password varchar(128) not null unique,
-	created_at timestamp not null default now
+    id integer primary key autoincrement,
+    username text not null unique,
+    email text not null unique,
+    password text not null unique,
+    created_at text not null default (datetime('now','localtime'))
 );
 
--- the prior index is case sensitive :(
-CREATE UNIQUE INDEX email_unique_idx on users (LOWER(email));
-CREATE UNIQUE INDEX username_unique_idx on users (LOWER(username));
+create unique index email_unique_idx on users (lower(email));
+create unique index username_unique_idx on users (lower(username));

--- a/migrations/20230608124202_create_sessions.sql
+++ b/migrations/20230608124202_create_sessions.sql
@@ -1,6 +1,5 @@
--- Add migration script here
 create table sessions (
-	id bigserial primary key,
-	user_id bigserial,
-	token varchar(128) unique not null
+    id integer primary key autoincrement,
+    user_id integer,
+    token text unique not null
 );


### PR DESCRIPTION
It seems that the current migrations were pulled from the Postgres migrations, and SQLite doesn't have some of the same concepts. This results in things like missing user IDs, meaning it's effectively useless. I've translated the schemas over to use SQLite types - was unsure about doing these in new migrations but given the current state I think it's safe enough to assume people's databases would already be in a broken state.

Also added sqlite3 to the Docker image for easier debugging.