### PR TITLE
Publish container image to GitHub Container Registry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,45 @@
+name: Build and push container image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+    
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Hi there!

I currently maintain a Helm Chart for atuin [1], and I wanted to add support for SQLite.
To do so, having a container image built automatically and available makes it much easier to deploy this Chart and self-host Atuin on environments like Kubernetes.

So this PR adds a GitHub Workflow that automatically builds and pushes the container image to [GitHub Container Registry](https://github.com/features/packages). Here is an example: https://github.com/rm3l/atuin-server-sqlite/pkgs/container/atuin-server-sqlite

Thanks!

[1] https://github.com/rm3l/helm-charts/tree/main/charts/atuin